### PR TITLE
fix: validate CNP unique county code

### DIFF
--- a/src/countyList.js
+++ b/src/countyList.js
@@ -199,4 +199,8 @@ export default {
     ISO: "GR",
     name: "Giurgiu",
   },
+  70: {
+    ISO: undefined,
+    name: "Cod unic",
+  },
 };

--- a/src/countyParser.js
+++ b/src/countyParser.js
@@ -1,7 +1,13 @@
 import counties from "./countyList";
 
+const normalizeCountyCode = (countyCode) => {
+  const normalized = parseInt(countyCode, 10);
+
+  return Number.isNaN(normalized) ? countyCode : String(normalized);
+};
+
 const countyParser = (countyCode) => {
-  const county = counties[countyCode];
+  const county = counties[countyCode] || counties[normalizeCountyCode(countyCode)];
 
   return {
     code: countyCode,
@@ -11,7 +17,7 @@ const countyParser = (countyCode) => {
 };
 
 const countyValidator = (countyCode) => {
-  return Object.keys(counties).includes(countyCode);
+  return Boolean(counties[countyCode] || counties[normalizeCountyCode(countyCode)]);
 };
 
 export { countyParser as default, countyValidator };

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -35,6 +35,17 @@ describe(`main parser`, () => {
     expect(instance.isValid).to.be.false;
   });
 
+  it(`should validate CNPs generated with the unique county code`, () => {
+    const instance = new Parser("1660302702618");
+
+    expect(instance.county).to.include({
+      code: "70",
+      name: "Cod unic",
+      ISO: undefined,
+    });
+    expect(instance.isValid).to.be.true;
+  });
+
   it(`should have methods`, () => {
     const instance = new Parser("6121212261011");
     const clock = sinon.useFakeTimers(new Date(2012, 11, 12).getTime());

--- a/test/countyParser.test.js
+++ b/test/countyParser.test.js
@@ -27,6 +27,22 @@ describe(`county parser`, () => {
     });
   });
 
+  it(`should return county code, name and ISO code if params is a two-digit string`, () => {
+    expect(countyParser("09")).to.include({
+      code: "09",
+      name: "Brăila",
+      ISO: "BR",
+    });
+  });
+
+  it(`should return county code for the unique registration code`, () => {
+    expect(countyParser("70")).to.include({
+      code: "70",
+      name: "Cod unic",
+      ISO: undefined,
+    });
+  });
+
   it(`should return object if county is not in county list`, () => {
     expect(countyParser("99")).to.include({
       code: "99",
@@ -39,6 +55,14 @@ describe(`county parser`, () => {
 describe(`county validator`, () => {
   it(`should return 'true' if county is in county list`, () => {
     expect(countyValidator("26")).to.be.true;
+  });
+
+  it(`should return 'true' if county is a two-digit county code`, () => {
+    expect(countyValidator("09")).to.be.true;
+  });
+
+  it(`should return 'true' if county is the unique registration code`, () => {
+    expect(countyValidator("70")).to.be.true;
   });
 
   it(`should return 'false' if county is not in county list`, () => {


### PR DESCRIPTION
Fixed the issue that I just reported: https://github.com/kislakiruben/parsecnp/issues/25