### PR TITLE
ci: tokenless npm publish via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,31 +7,37 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: yarn install --frozen-lockfile
       - run: yarn test
 
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the version bump commit back to master
+      id-token: write # enable npm provenance
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
-      - run: yarn config set version-git-message "Released v%s"
       - run: git config user.email "ruben@kislaki.net"
       - run: git config user.name "Ruben"
-      - run: yarn version --new-version ${{ github.event.release.tag_name }}
+      # Bump the version locally without creating a git tag (the release already has one).
+      - run: yarn version --new-version ${{ github.event.release.tag_name }} --no-git-tag-version
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - run: yarn publish
+      # Use `npm publish` (not `yarn publish`): it reliably reads NODE_AUTH_TOKEN from the
+      # .npmrc that setup-node writes. A misauthenticated request returns a misleading
+      # "Not found" (404), which is what broke the previous release.
+      - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: git push origin HEAD:master
+      - run: git commit -am "Released v${{ github.event.release.tag_name }}" && git push origin HEAD:master
         env:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: yarn install --frozen-lockfile
       - run: yarn test
 
@@ -19,12 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # push the version bump commit back to master
-      id-token: write # enable npm provenance
+      id-token: write # mint the OIDC token for npm Trusted Publishing
     steps:
       - uses: actions/checkout@v4
+      # Node 24 bundles npm >= 11.5.1, required for Trusted Publishing (OIDC).
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: git config user.email "ruben@kislaki.net"
       - run: git config user.name "Ruben"
@@ -32,12 +33,11 @@ jobs:
       - run: yarn version --new-version ${{ github.event.release.tag_name }} --no-git-tag-version
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      # Use `npm publish` (not `yarn publish`): it reliably reads NODE_AUTH_TOKEN from the
-      # .npmrc that setup-node writes. A misauthenticated request returns a misleading
-      # "Not found" (404), which is what broke the previous release.
-      - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Tokenless publish via npm Trusted Publishing: authentication uses the short-lived
+      # OIDC token (id-token: write) — no NPM_TOKEN secret needed. Requires a trusted
+      # publisher to be configured for this package on npmjs.com pointing at this workflow.
+      # Provenance is generated automatically.
+      - run: npm publish --access public
       - run: git commit -am "Released v${{ github.event.release.tag_name }}" && git push origin HEAD:master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

The `0.3.1` release failed with:

```
error Couldn't publish package: "https://registry.npmjs.org/parsecnp: Not found"
```

`parsecnp` is published and owned by `kislakiruben`, so this is **not** a missing-package error — npm returns `Not found` (404) for **unauthenticated** publish requests. The `NPM_TOKEN` was expired/invalid and `yarn publish` does not reliably consume the `NODE_AUTH_TOKEN` `.npmrc` written by `setup-node`.

Rather than rotate a long-lived token, this switches to **npm Trusted Publishing (OIDC)** — npm's recommended approach for CI/CD. No stored secret; GitHub Actions authenticates with a short-lived OIDC token minted per run.

## Changes

- Tokenless publish: `npm publish --access public` (no `NODE_AUTH_TOKEN`/`secrets.NPM_TOKEN`)
- Keep `id-token: write` (mints the OIDC token); provenance is now automatic
- Node `16` → `24` (bundles npm ≥ 11.5.1, required for OIDC publishing)
- `actions/checkout@v3` → `@v4`, `actions/setup-node@v1`/`@v3` → `@v4`
- `yarn version --no-git-tag-version` (the release already created the tag)
- Fix env var `github-token` → `GITHUB_TOKEN`

## Required before the next release (outside this PR)

1. On npmjs.com → **parsecnp** package → **Settings → Trusted Publishing**, add a GitHub Actions publisher:
   - Owner: `kislakiruben`, Repo: `parsecnp`, Workflow: `npm-publish.yml`, Environment: (blank)
2. After merge, the `NPM_TOKEN` repo secret can be deleted — it is no longer used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)