### PR TITLE
ci: drop broken post-publish push-to-master step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write # push the version bump commit back to master
       id-token: write # mint the OIDC token for npm Trusted Publishing
     steps:
       - uses: actions/checkout@v4
@@ -27,9 +26,9 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
-      - run: git config user.email "ruben@kislaki.net"
-      - run: git config user.name "Ruben"
-      # Bump the version locally without creating a git tag (the release already has one).
+      # Set the published version from the release tag. --no-git-tag-version keeps it local
+      # to the runner: it only affects the tarball npm publishes, not the repo (master is a
+      # protected branch and the bump is driven by the git tag, not package.json).
       - run: yarn version --new-version ${{ github.event.release.tag_name }} --no-git-tag-version
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -38,6 +37,3 @@ jobs:
       # publisher to be configured for this package on npmjs.com pointing at this workflow.
       # Provenance is generated automatically.
       - run: npm publish --access public
-      - run: git commit -am "Released v${{ github.event.release.tag_name }}" && git push origin HEAD:master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

`0.3.2` published successfully, but the run still failed on the final step:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
remote: - Required status check "unit-tests" is expected.
```

The trailing `git commit -am ... && git push origin HEAD:master` step pushes a version bump back to `master`, which is a protected branch — so the push is rejected.

That bump has **never** landed in any release (master's `package.json` is still `0.1.9` while npm is at `0.3.2`). The published version is driven by the git **release tag**, not by `package.json` in the repo, so the step was both broken and unnecessary.

## Changes

- Remove the `git commit && git push origin HEAD:master` step
- Drop the now-unused `contents: write` permission and `git config` author lines
- Keep `yarn version --no-git-tag-version` so the published tarball still carries the release-tag version

After this, the publish workflow runs fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)